### PR TITLE
Add Prometheus + Grafana Monitoring to Rollem

### DIFF
--- a/infra/k8s/grafana/grafana-config.yaml
+++ b/infra/k8s/grafana/grafana-config.yaml
@@ -1,0 +1,9 @@
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: grafana-config
+  namespace: grafana 
+  labels:
+    app: grafana
+data:

--- a/infra/k8s/grafana/grafana-service.yaml
+++ b/infra/k8s/grafana/grafana-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+  namespace: grafana 
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: grafana

--- a/infra/k8s/grafana/grafana.yaml
+++ b/infra/k8s/grafana/grafana.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: grafana 
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 3000
+            name: "graphana"
+        volumeMounts:
+        - name: grafana-config
+          mountPath: /config/
+        env:
+        - name: GF_INSTALL_PLUGINS
+          value: ""
+      volumes:
+        - name: grafana-config
+          configMap:
+            name: grafana-config

--- a/infra/k8s/prometheus/prometheus-config.yaml
+++ b/infra/k8s/prometheus/prometheus-config.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-conf
+  labels:
+    name: prometheus-conf
+  namespace: kube-system
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+
+    scrape_configs:
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name

--- a/infra/k8s/prometheus/prometheus-service.yaml
+++ b/infra/k8s/prometheus/prometheus-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: kube-system 
+  labels:
+    app: "prometheus"
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port:   '9090'
+spec:
+  selector:
+    app: prometheus
+  type: ClusterIP
+  ports:
+    - name: prometheus-port
+      port: 9090
+      targetPort: 9090

--- a/infra/k8s/prometheus/prometheus.yaml
+++ b/infra/k8s/prometheus/prometheus.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: kube-system
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          imagePullPolicy: Always
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            defaultMode: 420
+            name: prometheus-conf
+
+        - name: prometheus-storage-volume
+          emptyDir: {}

--- a/infra/k8s/rollem-next/rollem-next-deployment.yaml
+++ b/infra/k8s/rollem-next/rollem-next-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       containers:
       - name: rollem
         image: lemtzas/rollem-discord:2.6.7
+        ports:
+        - containerPort: 8080
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
Work on getting Grafana + Prometheus set up on the Rollem cluster.

The requirements are as follows:
- [x] Create the Grafana and Prometheus Deployments
- [ ] Configure Prometheus to scrape from Rollem pods (and maybe kube-api/kube-metrics)
    - Still needs a RBAC role so Prometheus can list all the pods in the cluster.
- [ ] Build out a sane dashboard for monitoring all of this and shove it in a configmap 