### PR TITLE
regex update on spoilered roll

### DIFF
--- a/packages/bot/src/common/behaviors/dice/dice.behavior.base.ts
+++ b/packages/bot/src/common/behaviors/dice/dice.behavior.base.ts
@@ -156,7 +156,7 @@ export abstract class DiceBehaviorBase extends BehaviorBase {
 
 
   protected rollSpoileredV1(trigger: Trigger, logTag: string, content: string, context: BehaviorContext, requireDice: boolean): string[] | null {
-    const match = content.match(/([sS]#)(?:(\d+)#\s*)?(.*)/i);
+    const match = content.match(/^([sS]#)(?:(\d+)#\s*)?(.*)/i);
 
     if (!match) {
       return null;


### PR DESCRIPTION
this should fix so roll isnt recognized if there is other preceeding text